### PR TITLE
Fix invalid font classes

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <section id="why">
-      <h2 class="courier-">Why We Mend</h2>
+      <h2 class="courier-prime-regular">Why We Mend</h2>
       <p class="courier-prime-regular">
       In a home studio with the soft presence of cats and fleeting lights, broken things wait to return to life. We mend not to hide the scars, but to let time, use, and care speak through the lacquer or metal that holds each fracture together.
       In the view of East Asian philosophy, all things — living or not — are part of the great assembly of beings. People, animals, plants, vessels, stones: all are 众生 (zhòngshēng), sentient and non-sentient, each carrying their own passage through time. To mend a vessel is to meet it as a fellow being — one that has carried, broken, waited, and now asks to return. We believe the way we treat our vessels is how we treat the other and therefore the self. In repairing what is chipped or cracked, we practice a quiet respect not only for the object, but for the shared condition we all inhabit: to bear traces of time, to carry meaning, and to continue.

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
  
   <main>
     <h1 id="name">circustreamsircustreamsircustreams...</h1>
-    <p class="courier-prime-italic">We mend to remember. We repair to continue.</p>
+      <p class="courier-prime-regular-italic">We mend to remember. We repair to continue.</p>
   </main>
 
   

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,12 @@
   font-style: italic;
 }
 
+.courier-prime-italic {
+  font-family: "Courier Prime", monospace;
+  font-weight: 400;
+  font-style: italic;
+}
+
 .courier-prime-bold-italic {
   font-family: "Courier Prime", monospace;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- use `courier-prime-regular` class on the About page
- update the home page tagline to `courier-prime-regular-italic`
- add an optional `.courier-prime-italic` style

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68579828bb588323a861b08f8d4f6f1f